### PR TITLE
fix(hl): use default hl groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,14 @@ The default options (as defined in [lua/config.lua](./blob/main/lua/pipeline/con
     },
   },
   highlights = {
-    PipelineRunIconSuccess = { link = 'LspDiagnosticsVirtualTextHint' },
-    PipelineRunIconFailure = { link = 'LspDiagnosticsVirtualTextError' },
-    PipelineRunIconStartup_failure = { link = 'LspDiagnosticsVirtualTextError' },
-    PipelineRunIconPending = { link = 'LspDiagnosticsVirtualTextWarning' },
-    PipelineRunIconRequested = { link = 'LspDiagnosticsVirtualTextWarning' },
-    PipelineRunIconWaiting = { link = 'LspDiagnosticsVirtualTextWarning' },
-    PipelineRunIconIn_progress = { link = 'LspDiagnosticsVirtualTextWarning' },
+    PipelineError = { link = 'DiagnosticError' },
+    PipelineRunIconSuccess = { link = 'DiagnosticOk' },
+    PipelineRunIconFailure = { link = 'DiagnosticError' },
+    PipelineRunIconStartup_failure = { link = 'DiagnosticError' },
+    PipelineRunIconPending = { link = 'DiagnosticWarn' },
+    PipelineRunIconRequested = { link = 'DiagnosticWarn' },
+    PipelineRunIconWaiting = { link = 'DiagnosticWarn' },
+    PipelineRunIconIn_progress = { link = 'DiagnosticWarn' },
     PipelineRunIconCancelled = { link = 'Comment' },
     PipelineRunIconSkipped = { link = 'Comment' },
     PipelineRunCancelled = { link = 'Comment' },
@@ -148,7 +149,6 @@ The default options (as defined in [lua/config.lua](./blob/main/lua/pipeline/con
     },
   },
 }
-
 ```
 
 ## lualine integration

--- a/lua/pipeline/config.lua
+++ b/lua/pipeline/config.lua
@@ -41,23 +41,21 @@ local defaultConfig = {
   ---@class pipeline.config.Highlights
   highlights = {
     ---@type vim.api.keyset.highlight
-    PipelineError = { link = 'LspDiagnosticsVirtualTextError' },
+    PipelineError = { link = 'DiagnosticError' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconSuccess = { link = 'LspDiagnosticsVirtualTextHint' },
+    PipelineRunIconSuccess = { link = 'DiagnosticOk' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconFailure = { link = 'LspDiagnosticsVirtualTextError' },
+    PipelineRunIconFailure = { link = 'DiagnosticError' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconStartup_failure = {
-      link = 'LspDiagnosticsVirtualTextError',
-    },
+    PipelineRunIconStartup_failure = { link = 'DiagnosticError' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconPending = { link = 'LspDiagnosticsVirtualTextWarning' },
+    PipelineRunIconPending = { link = 'DiagnosticWarn' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconRequested = { link = 'LspDiagnosticsVirtualTextWarning' },
+    PipelineRunIconRequested = { link = 'DiagnosticWarn' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconWaiting = { link = 'LspDiagnosticsVirtualTextWarning' },
+    PipelineRunIconWaiting = { link = 'DiagnosticWarn' },
     ---@type vim.api.keyset.highlight
-    PipelineRunIconIn_progress = { link = 'LspDiagnosticsVirtualTextWarning' },
+    PipelineRunIconIn_progress = { link = 'DiagnosticWarn' },
     ---@type vim.api.keyset.highlight
     PipelineRunIconCancelled = { link = 'Comment' },
     ---@type vim.api.keyset.highlight

--- a/lua/pipeline/config.lua
+++ b/lua/pipeline/config.lua
@@ -38,39 +38,24 @@ local defaultConfig = {
       in_progress = '●',
     },
   },
-  ---@class pipeline.config.Highlights
+  ---@alias hl_group 'PipelineError' | 'PipelineRunIconSuccess' | 'PipelineRunIconFailure' | 'PipelineRunIconStartup_failure' | 'PipelineRunIconPending' | 'PipelineRunIconRequested' | 'PipelineRunIconWaiting' | 'PipelineRunIconIn_progress' | 'PipelineRunIconCancelled' | 'PipelineRunIconSkipped' | 'PipelineRunCancelled' | 'PipelineRunSkipped' | 'PipelineJobCancelled' | 'PipelineJobSkipped' | 'PipelineStepCancelled' | 'PipelineStepSkipped'
+  ---@type table<hl_group, vim.api.keyset.highlight>
   highlights = {
-    ---@type vim.api.keyset.highlight
     PipelineError = { link = 'DiagnosticError' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconSuccess = { link = 'DiagnosticOk' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconFailure = { link = 'DiagnosticError' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconStartup_failure = { link = 'DiagnosticError' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconPending = { link = 'DiagnosticWarn' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconRequested = { link = 'DiagnosticWarn' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconWaiting = { link = 'DiagnosticWarn' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconIn_progress = { link = 'DiagnosticWarn' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconCancelled = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineRunIconSkipped = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineRunCancelled = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineRunSkipped = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineJobCancelled = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineJobSkipped = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineStepCancelled = { link = 'Comment' },
-    ---@type vim.api.keyset.highlight
     PipelineStepSkipped = { link = 'Comment' },
   },
   ---@type nui_split_options


### PR DESCRIPTION
I've changed the default highlight groups to default ones so that every colorscheme is supported out of the box.
