### PR TITLE
checking CI file existence in git root dir

### DIFF
--- a/lua/pipeline/providers/github/rest/init.lua
+++ b/lua/pipeline/providers/github/rest/init.lua
@@ -22,7 +22,7 @@ local defaultOptions = {
 local GithubRestProvider = Provider:extend()
 
 function GithubRestProvider.detect()
-  if not utils.file_exists('.github/workflows') then
+  if not utils.file_exists_in_git_root('.github/workflows') then
     return false
   end
 

--- a/lua/pipeline/providers/gitlab/graphql/init.lua
+++ b/lua/pipeline/providers/gitlab/graphql/init.lua
@@ -22,7 +22,7 @@ local defaultOptions = {
 local GitlabGraphQLProvider = Provider:extend()
 
 function GitlabGraphQLProvider.detect()
-  if not utils.file_exists('.gitlab-ci.yml') then
+  if not utils.file_exists_in_git_root('.gitlab-ci.yml') then
     return false
   end
 

--- a/lua/pipeline/utils.lua
+++ b/lua/pipeline/utils.lua
@@ -93,6 +93,16 @@ function M.group_by(fn, tbl)
   return m
 end
 
+
+---@param file string
+---@return boolean
+function M.file_exists_in_git_root(file)
+  local git_root_dir = vim.fn
+    .fnamemodify(vim.trim(vim.fn.system('git rev-parse --show-toplevel')), ':p')
+    :gsub('/$', '')
+  return vim.loop.fs_stat(git_root_dir .. "/" .. file) ~= nil
+end
+
 ---@param file string
 ---@return boolean
 function M.file_exists(file)


### PR DESCRIPTION
This PR fixes the CI file check in the `detect()` method of the providers so that it looks up the file in the git repositories root folder and not in the current working directory.

potentially fixes #21, potentially fixes #24