### PR TITLE
fix: Convert boolean workflow inputs into string

### DIFF
--- a/lua/pipeline/providers/github/rest/init.lua
+++ b/lua/pipeline/providers/github/rest/init.lua
@@ -274,7 +274,7 @@ function GithubRestProvider:dispatch(pipeline)
         local question = require('pipeline.ui.components.input') {
           prompt = prompt,
           title = pipeline.name,
-          default_value = input.default,
+          default_value = tostring(input.default),
           on_submit = function(value)
             input_values[name] = value
             ask_next()


### PR DESCRIPTION
This fix prevents from showing error in nui due to nil value passed to it. Instead, we now convert boolean to string (true/false) which is also accepted by APIs as valid input value for boolean variables