### PR TITLE
feat: Add rename_hosts mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,20 @@ The default options (as defined in [lua/config.lua](./blob/main/lua/pipeline/con
   --- How much workflow runs and jobs should be indented
   indent = 2,
   providers = {
-    github = {},
-    gitlab = {},
+    github = {
+      --- Mapping of names that should be renamed to resolvable hostnames
+      --- names are something that you've used as a repository url, that can't be resolved by this plugin,
+      --- like aliases from ssh config
+      --- for example: gh = "github.com"
+      rename_hosts = {}
+    },
+    gitlab = {
+      --- Mapping of names that should be renamed to resolvable hostnames
+      --- names are something that you've used as a repository url, that can't be resolved by this plugin,
+      --- like aliases from ssh config
+      --- for example: gl = "gitlab.com"
+      rename_hosts = {}
+    },
   },
   --- Allowed hosts to fetch data from, github.com is always allowed
   allowed_hosts = {},

--- a/lua/pipeline/config.lua
+++ b/lua/pipeline/config.lua
@@ -11,9 +11,17 @@ local defaultConfig = {
   ---@field gitlab? pipeline.providers.gitlab.graphql.Options
   providers = {
     github = {
+      --- Mapping of names that should be renamed to resolvable hostnames
+      --- names are something that you've used as a repository url, that can't be resolved by this plugin,
+      --- like aliases from ssh config
+      --- for example: gh = "github.com"
       rename_hosts = {}
     },
     gitlab = {
+      --- Mapping of names that should be renamed to resolvable hostnames
+      --- names are something that you've used as a repository url, that can't be resolved by this plugin,
+      --- like aliases from ssh config
+      --- for example: gl = "gitlab.com"
       rename_hosts = {}
     },
   },

--- a/lua/pipeline/config.lua
+++ b/lua/pipeline/config.lua
@@ -10,8 +10,12 @@ local defaultConfig = {
   ---@field github? pipeline.providers.github.rest.Options
   ---@field gitlab? pipeline.providers.gitlab.graphql.Options
   providers = {
-    github = {},
-    gitlab = {},
+    github = {
+      rename_hosts = {}
+    },
+    gitlab = {
+      rename_hosts = {}
+    },
   },
   --- Allowed hosts to fetch data from, github.com is always allowed
   --- @type string[]

--- a/lua/pipeline/providers/github/rest/init.lua
+++ b/lua/pipeline/providers/github/rest/init.lua
@@ -29,6 +29,13 @@ function GithubRestProvider.detect()
   local config = require('pipeline.config')
   local server, repo = git().get_current_repository()
 
+  for k, v in pairs(config.options.providers.github.rename_hosts) do
+    if k == server then
+      server = v
+      break
+    end
+  end
+
   if not config.is_host_allowed(server) then
     return
   end
@@ -45,12 +52,18 @@ function GithubRestProvider:init(opts)
   local server, repo = git().get_current_repository()
 
   self.server = server
+  for k, v in pairs(self.opts.rename_hosts) do
+    if k == server then
+      self.server = v
+      break
+    end
+  end
   self.repo = repo
 
   self.store.update_state(function(state)
     state.title = string.format('Github Workflows for %s', repo)
-    state.server = server
-    state.repo = repo
+    state.server = self.server
+    state.repo = self.repo
   end)
 end
 

--- a/lua/pipeline/providers/gitlab/graphql/init.lua
+++ b/lua/pipeline/providers/gitlab/graphql/init.lua
@@ -33,6 +33,13 @@ function GitlabGraphQLProvider.detect()
   local config = require('pipeline.config')
   local server, repo = git().get_current_repository()
 
+  for k, v in pairs(config.options.providers.gitlab.rename_hosts) do
+    if k == server then
+      server = v
+      break
+    end
+  end
+
   if not config.is_host_allowed(server) then
     return
   end
@@ -49,12 +56,18 @@ function GitlabGraphQLProvider:init(opts)
   local server, repo = git().get_current_repository()
 
   self.server = server
+  for k, v in pairs(self.opts.rename_hosts) do
+    if k == server then
+      self.server = v
+      break
+    end
+  end
   self.repo = repo
 
   self.store.update_state(function(state)
     state.title = string.format('Gitlab Pipelines for %s', repo)
-    state.server = server
-    state.repo = repo
+    state.server = self.server
+    state.repo = self.repo
   end)
 end
 


### PR DESCRIPTION
This add rename_hosts mapping to providers config. This can become useful for people using SSH to connect to Github/Gitlab and configured custom hostname in their .ssh/config. For instance in SSH config Github can be referenced as gh, and this can be used also in git's clone. This will set push/pull urls for origin to gh:owner/repo, making it impossible for pipeline.nvim to query APIs - it would try to make request to https://gh/api/.... This change add a way to translate back custom named provider hosts back to proper ones. Since this is for very specific usecases, there is no point in automating it (and it works without gh/glab cli commands)