### PR TITLE
feat: Allow choosing branch with will be used for dispatching workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ The default options (as defined in [lua/config.lua](./blob/main/lua/pipeline/con
   },
   --- Allowed hosts to fetch data from, github.com is always allowed
   allowed_hosts = {},
+  --- Configure which branch to use to dispatch workflow
+  --- set to "default" to use the repository default branch
+  --- set to "current" to use the branch you're currently checked out
+  --- set to any valid branch name to use that branch
+  --- @type string
+  dispatch_branch = "default",
   icons = {
     workflow_dispatch = '⚡️',
     conclusion = {

--- a/lua/pipeline/config.lua
+++ b/lua/pipeline/config.lua
@@ -54,6 +54,12 @@ local defaultConfig = {
   --- Allowed hosts to fetch data from, github.com is always allowed
   --- @type string[]
   allowed_hosts = {},
+  --- Configure which branch to use to dispatch workflow
+  --- set to "default" to use the repository default branch
+  --- set to "current" to use the branch you're currently checked out
+  --- set to any valid branch name to use that branch
+  --- @type string
+  dispatch_branch = "default",
   ---@class pipeline.config.Icons
   icons = {
     workflow_dispatch = '⚡️',
@@ -144,6 +150,13 @@ function M.resolve_host_for(provider, host)
       and M.options.providers[provider].resolve_host
       and M.options.providers[provider].resolve_host(host)
     or M.options.providers[provider].default_host
+end
+
+function M.get_dispatch_branch()
+  local git = require('pipeline.git')
+  return M.options.dispatch_branch == "default" and git.get_default_branch()
+    or M.options.dispatch_branch == "current" and git.get_current_branch()
+    or M.options.dispatch_branch
 end
 
 return M

--- a/lua/pipeline/providers/github/rest/init.lua
+++ b/lua/pipeline/providers/github/rest/init.lua
@@ -163,10 +163,11 @@ function GithubRestProvider:dispatch(pipeline)
   if pipeline then
     local server = store.get_state().server
     local repo = store.get_state().repo
+    local Config = require('pipeline.config')
 
     -- TODO should we get current ref instead or show an input with the
     --      default branch or current ref preselected?
-    local default_branch = require('pipeline.git').get_default_branch()
+    local dispatch_branch = Config.get_dispatch_branch()
     ---@type pipeline.providers.github.WorkflowDef|nil
     local workflow_config =
       require('pipeline.yaml').read_yaml_file(pipeline.meta.workflow_path)
@@ -198,7 +199,7 @@ function GithubRestProvider:dispatch(pipeline)
           server,
           repo,
           pipeline.pipeline_id,
-          default_branch,
+          dispatch_branch,
           {
             body = { inputs = input_values or {} },
             callback = function(_err, _res)


### PR DESCRIPTION
Setting allows to choose between "current" branch, repository "default" branch or enables setting any fixed branch that exists in the repository